### PR TITLE
chore: fix dependency security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-icons": "^5.4.0",
-    "react-router-dom": "^7.12.0",
+    "react-router-dom": "^7.18.2",
     "tmi.js": "^1.8.5",
     "typescript-cookie": "^1.0.6",
     "zustand": "^5.0.2"
@@ -71,15 +71,15 @@
       "glob@^10.2.2": "10.5.0",
       "glob@^10.3.7": "10.5.0",
       "glob@^10.3.10": "10.5.0",
-      "js-yaml@^4.1.0": "4.3.0",
+      "js-yaml@^4.1.0": "4.3.1",
       "@babel/core": "7.29.6",
       "@babel/helpers@^7.26.0": "7.26.10",
       "@babel/runtime@^7.12.5": "7.26.10",
       "picomatch@^2.3.1": "2.3.2",
       "picomatch@^4.0.2": "4.0.4",
       "picomatch@^4.0.3": "4.0.4",
-      "brace-expansion@^1.1.7": "1.1.16",
-      "brace-expansion@^5.0.2": "5.0.7",
+      "brace-expansion@^1.1.7": "1.1.18",
+      "brace-expansion@^5.0.2": "5.0.9",
       "fast-xml-builder": "1.2.0",
       "vite@^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0": "8.0.16",
       "vite@^5.0.0 || ^6.0.0 || ^7.0.0-0 || ^8.0.0-0": "8.0.16",
@@ -89,16 +89,12 @@
       "@protobufjs/utf8": "1.1.1",
       "ajv": "6.14.0",
       "@eslint/plugin-kit": "0.3.4",
-      "postcss": "8.5.12",
+      "postcss": "8.5.26",
+      "nanoid": "3.3.18",
       "uuid": "14.0.0",
       "ws": "8.21.0",
       "esbuild": "0.28.1",
       "websocket-driver": "0.7.5"
-    },
-    "auditConfig": {
-      "ignoreCves": [
-        "GHSA-w5hq-g745-h8pq"
-      ]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,15 +21,15 @@ overrides:
   glob@^10.2.2: 10.5.0
   glob@^10.3.7: 10.5.0
   glob@^10.3.10: 10.5.0
-  js-yaml@^4.1.0: 4.3.0
+  js-yaml@^4.1.0: 4.3.1
   '@babel/core': 7.29.6
   '@babel/helpers@^7.26.0': 7.26.10
   '@babel/runtime@^7.12.5': 7.26.10
   picomatch@^2.3.1: 2.3.2
   picomatch@^4.0.2: 4.0.4
   picomatch@^4.0.3: 4.0.4
-  brace-expansion@^1.1.7: 1.1.16
-  brace-expansion@^5.0.2: 5.0.7
+  brace-expansion@^1.1.7: 1.1.18
+  brace-expansion@^5.0.2: 5.0.9
   fast-xml-builder: 1.2.0
   vite@^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0: 8.0.16
   vite@^5.0.0 || ^6.0.0 || ^7.0.0-0 || ^8.0.0-0: 8.0.16
@@ -39,7 +39,8 @@ overrides:
   '@protobufjs/utf8': 1.1.1
   ajv: 6.14.0
   '@eslint/plugin-kit': 0.3.4
-  postcss: 8.5.12
+  postcss: 8.5.26
+  nanoid: 3.3.18
   uuid: 14.0.0
   ws: 8.21.0
   esbuild: 0.28.1
@@ -80,8 +81,8 @@ importers:
         specifier: ^5.4.0
         version: 5.7.0(react@19.2.8)
       react-router-dom:
-        specifier: ^7.12.0
-        version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^7.18.2
+        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tmi.js:
         specifier: ^1.8.5
         version: 1.8.5
@@ -1301,12 +1302,12 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -2076,8 +2077,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2308,8 +2309,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2438,8 +2439,8 @@ packages:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2486,15 +2487,15 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -3312,7 +3313,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4362,12 +4363,12 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5414,7 +5415,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -5607,15 +5608,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
     optional: true
 
   minipass@7.1.3:
@@ -5632,7 +5633,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -5757,9 +5758,9 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss@8.5.12:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5809,13 +5810,13 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-router-dom@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router-dom@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      react-router: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  react-router@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       cookie: 1.1.1
       react: 19.2.8
@@ -6281,7 +6282,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.26
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## 概要

Dependabot Alerts と `pnpm audit` で検出された依存関係の脆弱性を解消します。

## 変更内容

- `react-router-dom` / `react-router` を 7.18.2 に更新
- `brace-expansion` 1.x / 5.x を修正版へ更新
- `postcss`、`nanoid`、`js-yaml` を修正版へ更新
- 修正版 `uuid@14.0.0` を使用済みのため、不要になった audit ignore を削除
- lockfile を再生成し、先行 Dependabot 更新で解決された React / React DOM / TanStack Query なども同期

## 対応する Alert

- #116 `brace-expansion`
- #117 `postcss`
- #118 `brace-expansion`
- #119 `react-router`

## 影響

アプリケーションの公開 API や画面動作に変更はありません。依存関係の解決結果のみを更新します。

## 確認

- `pnpm install --frozen-lockfile`
- `pnpm audit --json`（全 severity 0）
- `mise run lint`
- `mise run test`（52 tests passed）
- `mise run build`